### PR TITLE
Remove lambda-proxy-cache dependency

### DIFF
--- a/awspds_mosaic/landsat/handlers/mosaic.py
+++ b/awspds_mosaic/landsat/handlers/mosaic.py
@@ -8,13 +8,17 @@ import urllib
 
 import mercantile
 
-from awspds_mosaic.utils import _compress_gz_json, _aws_put_data, get_mosaic_content
+from awspds_mosaic.utils import (
+    _compress_gz_json,
+    _aws_put_data,
+    get_mosaic_content,
+    get_hash,
+)
 from awspds_mosaic.landsat.stac import stac_to_mosaicJSON
 
 from loguru import logger
 
 from lambda_proxy.proxy import API
-from lambda_proxy_cache.proxy import get_hash
 
 app = API(name="awspds-mosaic-landsat-mosaic", debug=True)
 

--- a/awspds_mosaic/utils.py
+++ b/awspds_mosaic/utils.py
@@ -1,10 +1,11 @@
 """awspds_mosaic.utils: utility functions."""
 
-from typing import Dict, BinaryIO, Tuple
+from typing import Any, Dict, BinaryIO, Tuple
 
 import os
 import zlib
 import json
+import hashlib
 import functools
 import itertools
 from urllib.parse import urlparse
@@ -18,6 +19,13 @@ import mercantile
 from rio_tiler.utils import linear_rescale
 from rio_color.utils import scale_dtype, to_math_type
 from rio_color.operations import parse_operations
+
+
+def get_hash(**kwargs: Any) -> str:
+    """Create hash from dict."""
+    return hashlib.sha224(
+        json.dumps(kwargs, sort_keys=True, default=str).encode()
+    ).hexdigest()
 
 
 def _decompress_gz(gzip_buffer: BinaryIO) -> str:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ from setuptools import setup, find_packages
 
 # Runtime requirements.
 inst_reqs = [
-    "lambda-proxy-cache",
     "loguru",
     "mercantile",
     "Pillow",


### PR DESCRIPTION
Closes #9 

lambda-proxy-cache is currently only used for the simple `get_hash` function. Unless you have plans for deeper integration with `lambda-proxy-cache` in the future, removing the dependency wouldn't hurt.