### PR TITLE
Add cache-control header option through serverless.yml

### DIFF
--- a/awspds_mosaic/landsat/handlers/mosaic.py
+++ b/awspds_mosaic/landsat/handlers/mosaic.py
@@ -112,6 +112,7 @@ def create(
     methods=["GET"],
     cors=True,
     tag=["mosaic"],
+    cache_control=os.getenv("CACHE_CONTROL", None),
 )
 def info(mosaicid: str) -> Tuple[str, str, str]:
     """Handle /create requests."""
@@ -128,6 +129,7 @@ def info(mosaicid: str) -> Tuple[str, str, str]:
     payload_compression_method="gzip",
     binary_b64encode=True,
     tag=["metadata"],
+    cache_control=os.getenv("CACHE_CONTROL", None),
 )
 def _get_geojson(mosaicid: str = None, url: str = None) -> Tuple[str, str, str]:
     """
@@ -165,7 +167,13 @@ def _get_geojson(mosaicid: str = None, url: str = None) -> Tuple[str, str, str]:
     return ("OK", "application/json", json.dumps(geojson))
 
 
-@app.route("/favicon.ico", methods=["GET"], cors=True, tag=["other"])
+@app.route(
+    "/favicon.ico",
+    methods=["GET"],
+    cors=True,
+    tag=["other"],
+    cache_control=os.getenv("CACHE_CONTROL", None),
+)
 def favicon() -> Tuple[str, str, str]:
     """Favicon."""
     return ("EMPTY", "text/plain", "")

--- a/awspds_mosaic/landsat/handlers/tiles.py
+++ b/awspds_mosaic/landsat/handlers/tiles.py
@@ -34,6 +34,7 @@ app = API(name="awspds-mosaic-landsat-tiles", debug=False)
     payload_compression_method="gzip",
     binary_b64encode=True,
     tag=["metadata"],
+    cache_control=os.getenv("CACHE_CONTROL", None),
 )
 def tilejson(
     mosaicid: str, tile_format="png", tile_scale: int = 1, **kwargs: Any
@@ -73,6 +74,7 @@ def tilejson(
     payload_compression_method="gzip",
     binary_b64encode=True,
     tag=["tiles"],
+    cache_control=os.getenv("CACHE_CONTROL", None),
 )
 @app.route(
     "/<regex([0-9A-Fa-f]{56}):mosaicid>/<int:z>/<int:x>/<int:y>@<int:scale>x.npy",
@@ -81,6 +83,7 @@ def tilejson(
     payload_compression_method="gzip",
     binary_b64encode=True,
     tag=["tiles"],
+    cache_control=os.getenv("CACHE_CONTROL", None),
 )
 def npy_tiles(
     mosaicid: str,
@@ -141,6 +144,7 @@ def npy_tiles(
     payload_compression_method="gzip",
     binary_b64encode=True,
     tag=["tiles"],
+    cache_control=os.getenv("CACHE_CONTROL", None),
 )
 @app.route(
     "/<regex([0-9A-Fa-f]{56}):mosaicid>/<int:z>/<int:x>/<int:y>@<int:scale>x.<ext>",
@@ -149,6 +153,7 @@ def npy_tiles(
     payload_compression_method="gzip",
     binary_b64encode=True,
     tag=["tiles"],
+    cache_control=os.getenv("CACHE_CONTROL", None),
 )
 def tiles(
     mosaicid: str,
@@ -260,7 +265,13 @@ def tiles(
     )
 
 
-@app.route("/favicon.ico", methods=["GET"], cors=True, tag=["other"])
+@app.route(
+    "/favicon.ico",
+    methods=["GET"],
+    cors=True,
+    tag=["other"],
+    cache_control=os.getenv("CACHE_CONTROL", None),
+)
 def favicon() -> Tuple[str, str, str]:
     """Favicon."""
     return ("EMPTY", "text/plain", "")

--- a/awspds_mosaic/landsat/handlers/web.py
+++ b/awspds_mosaic/landsat/handlers/web.py
@@ -10,8 +10,20 @@ from lambda_proxy.proxy import API
 app = API(name="awspds-mosaic-landsat-web", add_docs=False)
 
 
-@app.route("/", methods=["GET"], cors=True, tag=["landing page"])
-@app.route("/index.html", methods=["GET"], cors=True, tag=["landing page"])
+@app.route(
+    "/",
+    methods=["GET"],
+    cors=True,
+    tag=["landing page"],
+    cache_control=os.getenv("CACHE_CONTROL", None),
+)
+@app.route(
+    "/index.html",
+    methods=["GET"],
+    cors=True,
+    tag=["landing page"],
+    cache_control=os.getenv("CACHE_CONTROL", None),
+)
 def _landsatlive() -> Tuple[str, str, str]:
     """
     Handle / requests.
@@ -33,7 +45,13 @@ def _landsatlive() -> Tuple[str, str, str]:
     )
 
 
-@app.route("/timeserie.html", methods=["GET"], cors=True, tag=["landing page"])
+@app.route(
+    "/timeserie.html",
+    methods=["GET"],
+    cors=True,
+    tag=["landing page"],
+    cache_control=os.getenv("CACHE_CONTROL", None),
+)
 def _timeserie() -> Tuple[str, str, str]:
     """
     Handle / requests.
@@ -55,7 +73,13 @@ def _timeserie() -> Tuple[str, str, str]:
     )
 
 
-@app.route("/favicon.ico", methods=["GET"], cors=True, tag=["other"])
+@app.route(
+    "/favicon.ico",
+    methods=["GET"],
+    cors=True,
+    tag=["other"],
+    cache_control=os.getenv("CACHE_CONTROL", None),
+)
 def favicon() -> Tuple[str, str, str]:
     """Favicon."""
     return ("EMPTY", "text/plain", "")

--- a/services/landsat/serverless.yml
+++ b/services/landsat/serverless.yml
@@ -39,6 +39,7 @@ functions:
     layers:
       - arn:aws:lambda:${self:provider.region}:524387336408:layer:gdal24-py37-cogeo:5
     environment:
+      CACHE_CONTROL: ${opt:cache-control, 'max-age=3600'}
       GDAL_DATA: /opt/share/gdal
       PROJ_LIB: /opt/share/proj
       MAPBOX_ACCESS_TOKEN: ${opt:token, ""}
@@ -59,6 +60,7 @@ functions:
     layers:
       - arn:aws:lambda:${self:provider.region}:524387336408:layer:gdal24-py37-cogeo:5
     environment:
+      CACHE_CONTROL: ${opt:cache-control, 'max-age=3600'}
       CPL_TMPDIR: /tmp
       CPL_VSIL_CURL_ALLOWED_EXTENSIONS: .tif,.TIF,.ovr
       GDAL_CACHEMAX: 512
@@ -86,6 +88,7 @@ functions:
     layers:
       - arn:aws:lambda:${self:provider.region}:524387336408:layer:gdal24-py37-cogeo:5
     environment:
+      CACHE_CONTROL: ${opt:cache-control, 'max-age=3600'}
       GDAL_DATA: /opt/share/gdal
       MOSAIC_DEF_BUCKET: ${opt:bucket}
       PROJ_LIB: /opt/share/proj
@@ -102,6 +105,7 @@ functions:
       layers:
         - arn:aws:lambda:${self:provider.region}:524387336408:layer:gdal24-py37-cogeo:5
       environment:
+        CACHE_CONTROL: ${opt:cache-control, 'max-age=3600'}
         CPL_TMPDIR: /tmp
         CPL_VSIL_CURL_ALLOWED_EXTENSIONS: .tif,.TIF,.ovr
         GDAL_CACHEMAX: 512

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from setuptools import setup, find_packages
 
 # Runtime requirements.
 inst_reqs = [
+    "lambda-proxy~=5.2",
     "lambda-proxy-cache",
     "loguru",
     "mercantile",


### PR DESCRIPTION
This adds a user-provided Cache-Control header to all GET methods.

Corresponds to https://github.com/developmentseed/cogeo-mosaic-tiler/pull/13